### PR TITLE
Add missing test for QuesoTextField

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -164,7 +164,7 @@ const openModal = () => {
 
 // Fields
 const TextField = ref("text field value");
-const TextFieldPassword = ref("text field password value");
+const TextFieldPassword = ref("password value");
 const TextArea = ref("text area value");
 const Checkbox = ref(true);
 const Select = ref([]);

--- a/src/components/QuesoTextField/QuesoTextField.test.ts
+++ b/src/components/QuesoTextField/QuesoTextField.test.ts
@@ -48,4 +48,18 @@ describe("QuesoTextField", () => {
 
         expect(wrapper.vm.localType.value).toBe("text");
     });
+
+    test("updates input type when .queso-text-field__password-toggle is clicked", async () => {
+        const wrapper = mount(QuesoTextField, {
+            props: {
+                type: "password",
+            },
+        });
+
+        const toggle = wrapper.find(".queso-text-field__password-toggle");
+        await toggle.trigger("click");
+
+        const input = wrapper.find(".queso-text-field__input");
+        expect(input.attributes("type")).toBe("text");
+    });
 });

--- a/src/components/QuesoTextField/QuesoTextField.vue
+++ b/src/components/QuesoTextField/QuesoTextField.vue
@@ -105,6 +105,7 @@ const emitPasswordVisibilityState = () => {
     --queso-text-field-password-toggle-left: auto;
     --queso-text-field-password-toggle-height: 100%;
     --queso-text-field-password-toggle-padding: 0.3rem;
+    --queso-text-field-password-cursor: pointer;
 
     position: relative;
     width: fit-content;
@@ -123,6 +124,7 @@ const emitPasswordVisibilityState = () => {
 
         background: none;
         border: 0rem;
+        cursor: var(--queso-text-field-password-cursor);
     }
 }
 </style>


### PR DESCRIPTION
This pull request adds a missing test for the QuesoTextField component. The test ensures that the input type is updated correctly when the password toggle is clicked.