### PR TITLE
Add hover and focus events to QuesoField component

### DIFF
--- a/src/components/QuesoField/QuesoField.vue
+++ b/src/components/QuesoField/QuesoField.vue
@@ -37,7 +37,7 @@ export interface Props {
 
 const props = defineProps<Props>();
 
-const emit = defineEmits(["update:modelValue"]);
+const emit = defineEmits(["update:modelValue", "update:active", "update:hover"]);
 
 /**
  * STATES
@@ -49,10 +49,12 @@ const { isRequired, isDisabled, isError, isReadOnly, isAutocomplete } = toRefs(p
 
 const toggleIsActive = (bool: boolean = false) => {
     isActive.value = bool;
+    emit("update:active", bool);
 };
 
 const toggleIsHover = (bool: boolean = false) => {
     isHover.value = bool;
+    emit("update:hover", bool);
 };
 
 const updateValue = (data: any) => {


### PR DESCRIPTION
This pull request adds the hover and focus events to the QuesoField component. It also includes the necessary changes to emit the "update:active" and "update:hover" events when the corresponding states change.