### PR TITLE
Upgrade grid mixin

### DIFF
--- a/src/assets/scss/mixins/_grid.scss
+++ b/src/assets/scss/mixins/_grid.scss
@@ -58,10 +58,10 @@ $largestGridGap: nth($largestGrid, 3);
 
 @mixin grid {
     display: grid;
-    grid-template-rows: repeat(var(--grid-rows, 1), 1fr);
+    grid-template-rows: repeat(var(--grid-rows, 1), minmax(0, 1fr));
     grid-template-columns: repeat(
         var(--grid-columns, $largestGridColumns),
-        1fr
+        minmax(0, 1fr)
     );
     column-gap: var(--grid-col-gap, var(--grid-gap, $largestGridGap));
     row-gap: var(--grid-row-gap, var(--grid-gap, $largestGridGap));

--- a/src/assets/scss/mixins/_grid.scss
+++ b/src/assets/scss/mixins/_grid.scss
@@ -21,7 +21,8 @@ $largestGridGap: nth($largestGrid, 3);
             @if $columns > 0 {
                 @for $i from 1 through $columns {
                     .col-#{$i}#{$infix} {
-                        grid-column: auto / span $i;
+                        --grid-col-start-default: auto;
+                        --grid-col-end-default: span #{$i};
                     }
                 }
 
@@ -29,27 +30,28 @@ $largestGridGap: nth($largestGrid, 3);
                 // Ends with `$columns - 1` because offsetting by the width of an entire row isn't possible.
                 @for $i from 1 through ($columns - 1) {
                     .start-#{$i}#{$infix} {
-                        grid-column-start: $i;
+                        --grid-col-start-default: $i;
                     }
                     .end-#{$i}#{$infix} {
-                        grid-column-end: $i * -1;
+                        --grid-col-end-default: $i * -1;
                     }
                 }
 
-                .col-all#{$infix} {
-                    grid-column: 1 / -1;
+                .col-full#{$infix} {
+                    --grid-col-start-default: 1;
+                    --grid-col-end-default: -1;
                 }
 
                 .col-half#{$infix} {
-                    grid-column: auto /
-                        span
-                        calc(var(--grid-columns, $largestGridColumns) / 2);
+                    --grid-col-start-default: auto;
+                    --grid-col-end-default: span
+                        calc(var(--grid-columns, #{$largestGridColumns}) / 2);
                 }
 
                 .col-third#{$infix} {
-                    grid-column: auto /
-                        span
-                        calc(var(--grid-columns, $largestGridColumns) / 3);
+                    --grid-col-start-default: auto;
+                    --grid-col-end-default: span
+                        calc(var(--grid-columns, #{$largestGridColumns}) / 3);
                 }
             }
         }
@@ -65,6 +67,11 @@ $largestGridGap: nth($largestGrid, 3);
     );
     column-gap: var(--grid-col-gap, var(--grid-gap, $largestGridGap));
     row-gap: var(--grid-row-gap, var(--grid-gap, $largestGridGap));
+
+    > * {
+        grid-column-start: dvar(--grid-col-start, 1);
+        grid-column-end: dvar(--grid-col-end, -1);
+    }
 
     @include make-cssgrid();
 }


### PR DESCRIPTION
This pull request upgrades the grid mixin by : 

- Use minmax() in the grid template to prevent columns from overflowing. 

- Use of CSS variables for columns instead of rewriting the property.

Closes #113