### PR TITLE
Fix grid() mixin start/end classes not working

### DIFF
--- a/src/assets/scss/mixins/_grid.scss
+++ b/src/assets/scss/mixins/_grid.scss
@@ -26,10 +26,10 @@ $grid: (
                 // Ends with `$columns - 1` because offsetting by the width of an entire row isn't possible.
                 @for $i from 1 through ($columns - 1) {
                     .start-#{$i}#{$infix} {
-                        --grid-col-start-default: $i;
+                        --grid-col-start-default: #{$i};
                     }
                     .end-#{$i}#{$infix} {
-                        --grid-col-end-default: $i * -1;
+                        --grid-col-end-default: #{$i * -1};
                     }
                 }
 


### PR DESCRIPTION
This pull request fixes the issue with the grid() mixin start/end classes not working. The problem was that the grid column start and end CSS variables were not being interpolated correctly. This PR adds interpolation on the grid column start and end CSS variable values, ensuring that the classes work as expected. 

Fixes #122