### PR TITLE
Release 0.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@allomambo/queso",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "description": "VueJS component library to use in conjunction with Arepa",
     "repository": "https://github.com/allomambo/queso.git",
     "author": "MamboMambo <allo@mambomambo.ca> (https://mambomambo.ca)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@allomambo/queso",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "description": "VueJS component library to use in conjunction with Arepa",
     "repository": "https://github.com/allomambo/queso.git",
     "author": "MamboMambo <allo@mambomambo.ca> (https://mambomambo.ca)",

--- a/src/assets/scss/functions/_shortcuts.scss
+++ b/src/assets/scss/functions/_shortcuts.scss
@@ -5,19 +5,30 @@
 /**
  * Shortcut to avoid having to type a css variable and its default with the same name everytime
  *
- * @param  {string} $var The name of the variable
- * @return {string}      A css variable with a default var() of the same name
+ * @param  {string} $var     The name of the css variable
+ * @param  {string} $default The default value to use if the variable is not set
+ * @return {string}          A css variable with a default var() of the same name
  *
  * @example 
- *     font-size: dvar(heading-font-size); ↴
+ *     font-size: dvar(--heading-font-size); ↴
  *     font-size: var(--heading-font-size, var(--heading-font-size-default));
+ *
+ * @example 
+ *     font-size: dvar(--button-color, red); ↴
+ *     font-size: var(--button-color, var(--button-color-default, red));
  */
-@function dvar($var) {
+@function dvar($var, $default: null) {
     @if not $var {
         @error "You must pass a variable name.";
     }
 
-    @return var(--#{$var}, var(--#{$var}-default));
+    // Legacy support: Add double dash if the variable doesn't starts with it
+    $var: if(str-index($var, "--") != 1, "--#{$var}", $var);
+
+    @return var(
+        #{$var},
+        if(not $default, var(#{$var}-default), var(#{$var}-default, $default))
+    );
 }
 
 /**

--- a/src/assets/scss/mixins/_grid.scss
+++ b/src/assets/scss/mixins/_grid.scss
@@ -9,11 +9,7 @@ $grid: (
     xl: 12 30px
 ) !default;
 
-$largestGrid: getLargestValue($grid, 1, "complete");
-$largestGridColumns: nth($largestGrid, 2);
-$largestGridGap: nth($largestGrid, 3);
-
-@mixin make-cssgrid($columns: $largestGridColumns, $bps: $breakpoints) {
+@mixin make-cssgrid($columns: 12, $bps: $breakpoints) {
     @each $breakpoint in map-keys($bps) {
         $infix: breakpoint-infix($breakpoint, $bps);
 
@@ -45,13 +41,13 @@ $largestGridGap: nth($largestGrid, 3);
                 .col-half#{$infix} {
                     --grid-col-start-default: auto;
                     --grid-col-end-default: span
-                        calc(var(--grid-columns, #{$largestGridColumns}) / 2);
+                        calc(var(--grid-columns, #{$columns}) / 2);
                 }
 
                 .col-third#{$infix} {
                     --grid-col-start-default: auto;
                     --grid-col-end-default: span
-                        calc(var(--grid-columns, #{$largestGridColumns}) / 3);
+                        calc(var(--grid-columns, #{$columns}) / 3);
                 }
             }
         }
@@ -59,6 +55,10 @@ $largestGridGap: nth($largestGrid, 3);
 }
 
 @mixin grid {
+    $largestGrid: getLargestValue($grid, 1, "complete");
+    $largestGridColumns: nth($largestGrid, 2);
+    $largestGridGap: nth($largestGrid, 3);
+
     display: grid;
     grid-template-rows: repeat(var(--grid-rows, 1), minmax(0, 1fr));
     grid-template-columns: repeat(
@@ -73,5 +73,5 @@ $largestGridGap: nth($largestGrid, 3);
         grid-column-end: dvar(--grid-col-end, -1);
     }
 
-    @include make-cssgrid();
+    @include make-cssgrid($largestGridColumns);
 }

--- a/src/assets/scss/mixins/_grid.scss
+++ b/src/assets/scss/mixins/_grid.scss
@@ -26,10 +26,10 @@ $grid: (
                 // Ends with `$columns - 1` because offsetting by the width of an entire row isn't possible.
                 @for $i from 1 through ($columns - 1) {
                     .start-#{$i}#{$infix} {
-                        --grid-col-start-default: $i;
+                        --grid-col-start-default: #{$i};
                     }
                     .end-#{$i}#{$infix} {
-                        --grid-col-end-default: $i * -1;
+                        --grid-col-end-default: #{$i * -1};
                     }
                 }
 

--- a/src/assets/scss/mixins/_grid.scss
+++ b/src/assets/scss/mixins/_grid.scss
@@ -21,7 +21,8 @@ $largestGridGap: nth($largestGrid, 3);
             @if $columns > 0 {
                 @for $i from 1 through $columns {
                     .col-#{$i}#{$infix} {
-                        grid-column: auto / span $i;
+                        --grid-col-start-default: auto;
+                        --grid-col-end-default: span #{$i};
                     }
                 }
 
@@ -29,27 +30,28 @@ $largestGridGap: nth($largestGrid, 3);
                 // Ends with `$columns - 1` because offsetting by the width of an entire row isn't possible.
                 @for $i from 1 through ($columns - 1) {
                     .start-#{$i}#{$infix} {
-                        grid-column-start: $i;
+                        --grid-col-start-default: $i;
                     }
                     .end-#{$i}#{$infix} {
-                        grid-column-end: $i * -1;
+                        --grid-col-end-default: $i * -1;
                     }
                 }
 
-                .col-all#{$infix} {
-                    grid-column: 1 / -1;
+                .col-full#{$infix} {
+                    --grid-col-start-default: 1;
+                    --grid-col-end-default: -1;
                 }
 
                 .col-half#{$infix} {
-                    grid-column: auto /
-                        span
-                        calc(var(--grid-columns, $largestGridColumns) / 2);
+                    --grid-col-start-default: auto;
+                    --grid-col-end-default: span
+                        calc(var(--grid-columns, #{$largestGridColumns}) / 2);
                 }
 
                 .col-third#{$infix} {
-                    grid-column: auto /
-                        span
-                        calc(var(--grid-columns, $largestGridColumns) / 3);
+                    --grid-col-start-default: auto;
+                    --grid-col-end-default: span
+                        calc(var(--grid-columns, #{$largestGridColumns}) / 3);
                 }
             }
         }
@@ -58,13 +60,18 @@ $largestGridGap: nth($largestGrid, 3);
 
 @mixin grid {
     display: grid;
-    grid-template-rows: repeat(var(--grid-rows, 1), 1fr);
+    grid-template-rows: repeat(var(--grid-rows, 1), minmax(0, 1fr));
     grid-template-columns: repeat(
         var(--grid-columns, $largestGridColumns),
-        1fr
+        minmax(0, 1fr)
     );
     column-gap: var(--grid-col-gap, var(--grid-gap, $largestGridGap));
     row-gap: var(--grid-row-gap, var(--grid-gap, $largestGridGap));
+
+    > * {
+        grid-column-start: dvar(--grid-col-start, 1);
+        grid-column-end: dvar(--grid-col-end, -1);
+    }
 
     @include make-cssgrid();
 }


### PR DESCRIPTION
This release fixes the issue with the `grid()` mixin start/end classes not working. The problem was that the grid column start and end CSS variables were not being interpolated correctly.