### PR TITLE
Add emits when scrolled top/bottom and fix arrivedStateBottom on resize

### DIFF
--- a/src/components/QuesoScrollable/QuesoScrollable.vue
+++ b/src/components/QuesoScrollable/QuesoScrollable.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch, watchEffect } from "vue";
 import { useScroll, useResizeObserver } from "@vueuse/core";
 
 import type { QuesoScrollableProps } from "./types";
@@ -15,6 +15,11 @@ import type { QuesoScrollableProps } from "./types";
 const props = withDefaults(defineProps<QuesoScrollableProps>(), {
     offset: 0,
 });
+
+const emit = defineEmits<{
+    "scroll:top": [];
+    "scroll:bottom": [];
+}>();
 
 const content = ref<HTMLElement>();
 
@@ -41,6 +46,16 @@ const scrollableClasses = computed(() => ({
     "is-scrolled-top": arrivedState.top,
     "is-scrolled-bottom": arrivedState.bottom || !contentIsOverflowing.value,
 }));
+
+watchEffect(() => {
+    if (arrivedState.top) {
+        emit("scroll:top");
+    }
+
+    if (arrivedState.bottom || !contentIsOverflowing.value) {
+        emit("scroll:bottom");
+    }
+});
 </script>
 
 <style lang="scss">

--- a/src/components/QuesoScrollable/QuesoScrollable.vue
+++ b/src/components/QuesoScrollable/QuesoScrollable.vue
@@ -10,13 +10,9 @@
 import { computed, ref } from "vue";
 import { useScroll, useResizeObserver } from "@vueuse/core";
 
-// Props / Emits
-export interface Props {
-    shadows?: boolean;
-    offset?: number;
-}
+import type { QuesoScrollableProps } from "./types";
 
-const props = withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<QuesoScrollableProps>(), {
     offset: 0,
 });
 

--- a/src/components/QuesoScrollable/index.ts
+++ b/src/components/QuesoScrollable/index.ts
@@ -1,3 +1,4 @@
 import QuesoScrollable from "./QuesoScrollable.vue";
 
 export default QuesoScrollable;
+export type * from "./types";

--- a/src/components/QuesoScrollable/types.ts
+++ b/src/components/QuesoScrollable/types.ts
@@ -1,0 +1,4 @@
+export interface QuesoScrollableProps {
+    shadows?: boolean;
+    offset?: number;
+}


### PR DESCRIPTION
This pull request fixes the issue where the scroll top and bottom events were not being emitted correctly in the QuesoScrollable component. The issue was resolved by adding the necessary code to emit the "scroll:top:arrived" and "scroll:bottom:arrived" events when the user scrolls to the top or bottom of the scrollable content.

Closes #139