### PR TITLE
Fix container classes to use -default css variable

### DIFF
--- a/src/assets/scss/mixins/_containers.scss
+++ b/src/assets/scss/mixins/_containers.scss
@@ -47,8 +47,8 @@ $containers: (
                         $container-width: max(#{$width}, #{$container-ratio});
                     }
 
-                    --container-width: #{$container-width};
-                    --container-gap: #{$gap};
+                    --container-width-default: #{$container-width};
+                    --container-gap-default: #{$gap};
                 }
             }
         }

--- a/src/assets/scss/mixins/_containers.scss
+++ b/src/assets/scss/mixins/_containers.scss
@@ -79,14 +79,15 @@ $containers: (
 
     // Set CSS custom properties
     --container-width-default: #{$container-width};
+    --container-max-width-default: calc(100% - (#{dvar(--container-gap)} * 2));
     --container-gap-default: #{$gap};
     --container-margin-left-default: auto;
     --container-margin-right-default: auto;
 
     // Apply styles
     display: block;
-    width: dvar(container-width);
-    max-width: calc(100% - (#{dvar(container-gap)} * 2));
-    margin-left: dvar(container-margin-left);
-    margin-right: dvar(container-margin-right);
+    width: dvar(--container-width);
+    max-width: dvar(--container-max-width);
+    margin-left: dvar(--container-margin-left);
+    margin-right: dvar(--container-margin-right);
 }

--- a/src/assets/scss/mixins/_containers.scss
+++ b/src/assets/scss/mixins/_containers.scss
@@ -78,6 +78,7 @@ $containers: (
     }
 
     // Set CSS custom properties
+    --container-display-default: block;
     --container-width-default: #{$container-width};
     --container-max-width-default: calc(100% - (#{dvar(--container-gap)} * 2));
     --container-gap-default: #{$gap};
@@ -85,7 +86,7 @@ $containers: (
     --container-margin-right-default: auto;
 
     // Apply styles
-    display: block;
+    display: dvar(--container-display);
     width: dvar(--container-width);
     max-width: dvar(--container-max-width);
     margin-left: dvar(--container-margin-left);

--- a/src/assets/scss/mixins/_grid.scss
+++ b/src/assets/scss/mixins/_grid.scss
@@ -59,7 +59,7 @@ $grid: (
     $largestGridColumns: nth($largestGrid, 2);
     $largestGridGap: nth($largestGrid, 3);
 
-    display: grid;
+    display: var(--grid-display, grid);
     grid-template-rows: repeat(var(--grid-rows, 1), minmax(0, 1fr));
     grid-template-columns: repeat(
         var(--grid-columns, $largestGridColumns),

--- a/src/assets/scss/mixins/_stack.scss
+++ b/src/assets/scss/mixins/_stack.scss
@@ -98,7 +98,7 @@ $stack-gap: 30px !default;
     }
 
     // Apply styles
-    display: flex;
+    display: var(--#{$var-prefix}-display, flex);
     align-items: var(--#{$var-prefix}-align, #{$align});
     justify-content: var(--#{$var-prefix}-justify, #{$justify});
     flex-direction: var(--#{$var-prefix}-direction, #{$direction});


### PR DESCRIPTION
Fixes issue #126

This pull request fixes the container classes to use the -default css variable instead of hardcoding the values. The changes include updating the container-width, container-gap, and container-display properties to use the -default css variable. Additionally, variations of the container classes now also use the -default css variable. This ensures consistency and makes it easier to customize the container styles.