### PR TITLE
Grid mixin / Use dvar and more options

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -85,6 +85,18 @@
     <QuesoCheckbox name="checkbox" label="QuesoCheckbox" v-model="Checkbox" />
     <QuesoSelect name="select" label="QuesoSelect" :options="dataOptions" v-model="Select" />
     <QuesoSwitch name="switch" label="QuesoSwitch" v-model="Switch" />
+    <hr />
+
+    <h3>Grid</h3>
+    <div class="l-grid">
+        <template v-for="i in gridColumns">
+            <div :class="`col-${i} inner`">col-{{ i }}</div>
+            <div v-if="i != gridColumns" :class="`col-${gridColumns - i} inner`">col-{{ gridColumns - i }}</div>
+        </template>
+        <div class="col-full inner">col-full</div>
+        <div class="col-half inner">col-half</div>
+        <div class="col-half inner">col-half</div>
+    </div>
 </template>
 
 <script setup lang="ts">
@@ -162,10 +174,21 @@ const TextArea = ref("text area value");
 const Checkbox = ref(true);
 const Select = ref([]);
 const Switch = ref(false);
+
+// Grid
+const gridColumns = 8;
 </script>
 
 <style lang="scss">
 :root {
     --queso-scrollable-height: 15rem;
+}
+
+.l-grid {
+    @include grid($columns: 8, $gap: 10px, $var-prefix: "queso");
+
+    > * {
+        outline: 1px dashed black;
+    }
 }
 </style>

--- a/src/assets/scss/mixins/_grid.scss
+++ b/src/assets/scss/mixins/_grid.scss
@@ -9,7 +9,7 @@ $grid: (
     xl: 12 30px
 ) !default;
 
-@mixin make-cssgrid($columns: 12, $bps: $breakpoints) {
+@mixin make-cssgrid($columns: 12, $var-prefix: "grid", $bps: $breakpoints) {
     @each $breakpoint in map-keys($bps) {
         $infix: breakpoint-infix($breakpoint, $bps);
 
@@ -17,8 +17,8 @@ $grid: (
             @if $columns > 0 {
                 @for $i from 1 through $columns {
                     .col-#{$i}#{$infix} {
-                        --grid-col-start-default: auto;
-                        --grid-col-end-default: span #{$i};
+                        --#{$var-prefix}-col-start-default: auto;
+                        --#{$var-prefix}-col-end-default: span #{$i};
                     }
                 }
 
@@ -26,52 +26,58 @@ $grid: (
                 // Ends with `$columns - 1` because offsetting by the width of an entire row isn't possible.
                 @for $i from 1 through ($columns - 1) {
                     .start-#{$i}#{$infix} {
-                        --grid-col-start-default: #{$i};
+                        --#{$var-prefix}-col-start-default: #{$i};
                     }
                     .end-#{$i}#{$infix} {
-                        --grid-col-end-default: #{$i * -1};
+                        --#{$var-prefix}-col-end-default: #{$i * -1};
                     }
                 }
 
                 .col-full#{$infix} {
-                    --grid-col-start-default: 1;
-                    --grid-col-end-default: -1;
+                    --#{$var-prefix}-col-start-default: 1;
+                    --#{$var-prefix}-col-end-default: -1;
                 }
 
                 .col-half#{$infix} {
-                    --grid-col-start-default: auto;
-                    --grid-col-end-default: span
-                        calc(var(--grid-columns, #{$columns}) / 2);
+                    --#{$var-prefix}-col-start-default: auto;
+                    --#{$var-prefix}-col-end-default: span
+                        calc(var(--#{$var-prefix}-columns, #{$columns}) / 2);
                 }
 
                 .col-third#{$infix} {
-                    --grid-col-start-default: auto;
-                    --grid-col-end-default: span
-                        calc(var(--grid-columns, #{$columns}) / 3);
+                    --#{$var-prefix}-col-start-default: auto;
+                    --#{$var-prefix}-col-end-default: span
+                        calc(var(--#{$var-prefix}-columns, #{$columns}) / 3);
                 }
             }
         }
     }
 }
 
-@mixin grid {
+@mixin grid($var-prefix: "grid") {
     $largestGrid: getLargestValue($grid, 1, "complete");
     $largestGridColumns: nth($largestGrid, 2);
     $largestGridGap: nth($largestGrid, 3);
 
-    display: var(--grid-display, grid);
-    grid-template-rows: repeat(var(--grid-rows, 1), minmax(0, 1fr));
+    display: var(--#{$var-prefix}-display, grid);
+    grid-template-rows: repeat(var(--#{$var-prefix}-rows, 1), minmax(0, 1fr));
     grid-template-columns: repeat(
-        var(--grid-columns, $largestGridColumns),
+        var(--#{$var-prefix}-columns, $largestGridColumns),
         minmax(0, 1fr)
     );
-    column-gap: var(--grid-col-gap, var(--grid-gap, $largestGridGap));
-    row-gap: var(--grid-row-gap, var(--grid-gap, $largestGridGap));
+    column-gap: var(
+        --#{$var-prefix}-col-gap,
+        var(--#{$var-prefix}-gap, $largestGridGap)
+    );
+    row-gap: var(
+        --#{$var-prefix}-row-gap,
+        var(--#{$var-prefix}-gap, $largestGridGap)
+    );
 
     > * {
-        grid-column-start: dvar(--grid-col-start, 1);
-        grid-column-end: dvar(--grid-col-end, -1);
+        grid-column-start: dvar(--#{$var-prefix}-col-start, 1);
+        grid-column-end: dvar(--#{$var-prefix}-col-end, -1);
     }
 
-    @include make-cssgrid($largestGridColumns);
+    @include make-cssgrid($largestGridColumns, $var-prefix);
 }

--- a/src/assets/scss/mixins/_grid.scss
+++ b/src/assets/scss/mixins/_grid.scss
@@ -55,30 +55,29 @@ $grid: (
     }
 }
 
-@mixin grid($var-prefix: "grid") {
+@mixin grid($columns: null, $gap: null, $var-prefix: "grid") {
     $largestGrid: getLargestValue($grid, 1, "complete");
-    $largestGridColumns: nth($largestGrid, 2);
-    $largestGridGap: nth($largestGrid, 3);
+
+    @if $columns == null {
+        $columns: nth($largestGrid, 2);
+    }
+    @if $gap == null {
+        $gap: nth($largestGrid, 3);
+    }
 
     display: var(--#{$var-prefix}-display, grid);
     grid-template-rows: repeat(var(--#{$var-prefix}-rows, 1), minmax(0, 1fr));
     grid-template-columns: repeat(
-        var(--#{$var-prefix}-columns, $largestGridColumns),
+        var(--#{$var-prefix}-columns, $columns),
         minmax(0, 1fr)
     );
-    column-gap: var(
-        --#{$var-prefix}-col-gap,
-        var(--#{$var-prefix}-gap, $largestGridGap)
-    );
-    row-gap: var(
-        --#{$var-prefix}-row-gap,
-        var(--#{$var-prefix}-gap, $largestGridGap)
-    );
+    column-gap: var(--#{$var-prefix}-col-gap, var(--#{$var-prefix}-gap, $gap));
+    row-gap: var(--#{$var-prefix}-row-gap, var(--#{$var-prefix}-gap, $gap));
 
     > * {
         grid-column-start: dvar(--#{$var-prefix}-col-start, 1);
         grid-column-end: dvar(--#{$var-prefix}-col-end, -1);
     }
 
-    @include make-cssgrid($largestGridColumns, $var-prefix);
+    @include make-cssgrid($columns, $var-prefix);
 }

--- a/src/assets/scss/mixins/_grid.scss
+++ b/src/assets/scss/mixins/_grid.scss
@@ -55,18 +55,30 @@ $grid: (
     }
 }
 
-@mixin grid($columns: null, $gap: null, $var-prefix: "grid") {
-    $largestGrid: getLargestValue($grid, 1, "complete");
+@mixin grid(
+    $columns: null,
+    $rows: 1,
+    $gap: null,
+    $var-prefix: "grid",
+    $bps: $breakpoints
+) {
+    @if $columns == null or $gap == null {
+        $largestGrid: getLargestValue($grid, 1, "complete");
 
-    @if $columns == null {
-        $columns: nth($largestGrid, 2);
-    }
-    @if $gap == null {
-        $gap: nth($largestGrid, 3);
+        @if $columns == null {
+            $columns: nth($largestGrid, 2);
+        }
+
+        @if $gap == null {
+            $gap: nth($largestGrid, 3);
+        }
     }
 
     display: var(--#{$var-prefix}-display, grid);
-    grid-template-rows: repeat(var(--#{$var-prefix}-rows, 1), minmax(0, 1fr));
+    grid-template-rows: repeat(
+        var(--#{$var-prefix}-rows, $rows),
+        minmax(0, 1fr)
+    );
     grid-template-columns: repeat(
         var(--#{$var-prefix}-columns, $columns),
         minmax(0, 1fr)
@@ -79,5 +91,5 @@ $grid: (
         grid-column-end: dvar(--#{$var-prefix}-col-end, -1);
     }
 
-    @include make-cssgrid($columns, $var-prefix);
+    @include make-cssgrid($columns, $var-prefix, $bps);
 }

--- a/src/assets/scss/mixins/_grid.scss
+++ b/src/assets/scss/mixins/_grid.scss
@@ -33,6 +33,7 @@ $grid: (
                     }
                 }
 
+                .col-all#{$infix},
                 .col-full#{$infix} {
                     --#{$var-prefix}-col-start-default: 1;
                     --#{$var-prefix}-col-end-default: -1;


### PR DESCRIPTION
This pull request includes changes to the grid mixin to use the dvar and add options. It also brings back the col-all class for legacy compatibility. Additionally, it adds columns and gap props, rows and bps props for more control. Finally, it adds the grid in app.vue.

Closes #142