### PR TITLE
Fix clickable behavior for router-link

### DIFF
--- a/src/components/QuesoClickable/QuesoClickable.vue
+++ b/src/components/QuesoClickable/QuesoClickable.vue
@@ -3,12 +3,9 @@
         :is="markup"
         class="queso-clickable"
         :class="clickableClasses"
-        :href="clickableHref"
-        :to="clickableTo"
-        :target="clickableTarget"
-        :download="clickableDownload"
         :disabled="clickableDisabled"
         :aria-disabled="clickableDisabled"
+        v-bind="anchorAttributes"
     >
         <slot></slot>
     </component>
@@ -26,14 +23,30 @@ const props = withDefaults(defineProps<QuesoClickableProps>(), {
 const { isExternal, isDisabled, isDownload, markup, url } = toRefs(props);
 
 const isAnchor = computed<boolean>(() => markup.value === "a");
-const isRouter = computed<boolean>(() => markup.value === "router-link");
+const isRouter = computed<boolean>(() => markup.value === "router-link" && typeof url.value === "object");
+
+// Attributes when anchor and router-link tags
+const anchorAttributes = computed(() => {
+    let attrs: object = {};
+
+    if (isRouter.value) {
+        attrs = {
+            to: url.value,
+        };
+    } else if (isAnchor.value) {
+        attrs = {
+            href: url.value,
+            target: clickableTarget.value,
+            download: clickableDownload.value,
+        };
+    }
+
+    return attrs;
+});
 
 // Computeds
-const clickableHref = computed(() => (isAnchor.value || isRouter.value ? url.value : null));
-const clickableTo = computed(() => (isRouter.value ? url.value : null));
 const clickableTarget = computed(() => (isAnchor.value && isExternal.value ? "_blank" : null));
-
-const clickableDisabled = computed(() => (isDisabled.value ? true : null));
+const clickableDisabled = computed(() => (isDisabled.value ? "" : null));
 const clickableDownload = computed(() => (isAnchor.value && isDownload.value ? "" : null));
 
 // CSS classes
@@ -45,7 +58,6 @@ const clickableClasses = computed(() => ({
 
 <style lang="scss">
 .queso-clickable {
-    //--- State: Disabled ---//
     &.is-disabled {
         @include unselectable;
     }

--- a/src/components/QuesoClickable/QuesoClickable.vue
+++ b/src/components/QuesoClickable/QuesoClickable.vue
@@ -3,43 +3,44 @@
         :is="markup"
         class="queso-clickable"
         :class="clickableClasses"
-        :rel="clickableRel"
         :href="clickableHref"
         :to="clickableTo"
         :target="clickableTarget"
         :download="clickableDownload"
         :disabled="clickableDisabled"
         :aria-disabled="clickableDisabled"
-        :aria-label="ariaLabel"
     >
         <slot></slot>
     </component>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, toRefs } from "vue";
 
 import type { QuesoClickableProps } from "./types";
 
-// Props
 const props = withDefaults(defineProps<QuesoClickableProps>(), {
     markup: "button",
 });
 
+const { isExternal, isDisabled, isDownload, markup, url } = toRefs(props);
+
+const isAnchor = computed<boolean>(() => markup.value === "a");
+const isRouter = computed<boolean>(() => markup.value === "router-link");
+
 // Computeds
+const clickableHref = computed(() => (isAnchor.value || isRouter.value ? url.value : null));
+const clickableTo = computed(() => (isRouter.value ? url.value : null));
+const clickableTarget = computed(() => (isAnchor.value && isExternal.value ? "_blank" : null));
+
+const clickableDisabled = computed(() => (isDisabled.value ? true : null));
+const clickableDownload = computed(() => (isAnchor.value && isDownload.value ? "" : null));
+
+// CSS classes
 const clickableClasses = computed(() => ({
-    "is-disabled": props.isDisabled,
+    "is-download": clickableDownload.value !== null,
+    "is-disabled": isDisabled.value,
 }));
-
-const clickableDisabled = computed(() => (props.isDisabled ? true : null));
-
-const clickableHref = computed(() => (props.markup === "a" || props.markup === "router-link" ? props.url : null));
-const clickableTo = computed(() => (props.markup === "router-link" ? props.url : null));
-
-const isExternal = computed(() => (props.isExternal ? "_blank" : "_self"));
-const clickableTarget = computed(() => (props.markup === "a" ? isExternal.value : null));
-const clickableRel = computed(() => (props.markup === "a" ? "noopener" : null));
-const clickableDownload = computed(() => (props.markup === "a" && props.isDownload ? "" : null));
 </script>
 
 <style lang="scss">

--- a/src/components/QuesoClickable/QuesoClickable.vue
+++ b/src/components/QuesoClickable/QuesoClickable.vue
@@ -44,18 +44,8 @@ const clickableDownload = computed(() => (props.markup === "a" && props.isDownlo
 
 <style lang="scss">
 .queso-clickable {
-    display: var(--queso-clickable-display, inline-flex);
-    align-items: var(--queso-clickable-align, center);
-    justify-content: var(--queso-clickable-justify, center);
-    cursor: pointer;
-
-    /*==============================
-    =           STATES             =
-    ==============================*/
-
-    //--- DISABLED ---//
-    &[disabled],
-    &[aria-disabled="true"] {
+    //--- State: Disabled ---//
+    &.is-disabled {
         @include unselectable;
     }
 }

--- a/src/components/QuesoClickable/QuesoClickable.vue
+++ b/src/components/QuesoClickable/QuesoClickable.vue
@@ -1,6 +1,6 @@
 <template>
     <component
-        :is="tag"
+        :is="markup"
         class="queso-clickable"
         :class="clickableClasses"
         :rel="clickableRel"
@@ -19,20 +19,11 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+import type { QuesoClickableProps } from "./types";
+
 // Props
-type TagOptions = "button" | "a" | "router-link" | "div" | "span";
-
-interface Props {
-    tag?: TagOptions;
-    url?: string;
-    isDisabled?: boolean;
-    isExternal?: boolean;
-    isDownload?: boolean;
-    ariaLabel?: string;
-}
-
-const props = withDefaults(defineProps<Props>(), {
-    tag: "button",
+const props = withDefaults(defineProps<QuesoClickableProps>(), {
+    markup: "button",
 });
 
 // Computeds
@@ -42,13 +33,13 @@ const clickableClasses = computed(() => ({
 
 const clickableDisabled = computed(() => (props.isDisabled ? true : null));
 
-const clickableHref = computed(() => (props.tag === "a" || props.tag === "router-link" ? props.url : null));
-const clickableTo = computed(() => (props.tag === "router-link" ? props.url : null));
+const clickableHref = computed(() => (props.markup === "a" || props.markup === "router-link" ? props.url : null));
+const clickableTo = computed(() => (props.markup === "router-link" ? props.url : null));
 
 const isExternal = computed(() => (props.isExternal ? "_blank" : "_self"));
-const clickableTarget = computed(() => (props.tag === "a" ? isExternal.value : null));
-const clickableRel = computed(() => (props.tag === "a" ? "noopener" : null));
-const clickableDownload = computed(() => (props.tag === "a" && props.isDownload ? "" : null));
+const clickableTarget = computed(() => (props.markup === "a" ? isExternal.value : null));
+const clickableRel = computed(() => (props.markup === "a" ? "noopener" : null));
+const clickableDownload = computed(() => (props.markup === "a" && props.isDownload ? "" : null));
 </script>
 
 <style lang="scss">

--- a/src/components/QuesoClickable/index.ts
+++ b/src/components/QuesoClickable/index.ts
@@ -1,3 +1,4 @@
 import QuesoClickable from "./QuesoClickable.vue";
 
 export default QuesoClickable;
+export type * from "./types";

--- a/src/components/QuesoClickable/types.ts
+++ b/src/components/QuesoClickable/types.ts
@@ -6,5 +6,4 @@ export interface QuesoClickableProps {
     isDisabled?: boolean;
     isExternal?: boolean;
     isDownload?: boolean;
-    ariaLabel?: string;
 }

--- a/src/components/QuesoClickable/types.ts
+++ b/src/components/QuesoClickable/types.ts
@@ -1,0 +1,10 @@
+export type ClickableTag = "button" | "a" | "router-link" | "div" | "span";
+
+export interface QuesoClickableProps {
+    markup?: ClickableTag;
+    url?: string | object;
+    isDisabled?: boolean;
+    isExternal?: boolean;
+    isDownload?: boolean;
+    ariaLabel?: string;
+}


### PR DESCRIPTION
This pull request fixes the issue where the `router-link` tag was not clickable. It adds the `href` attribute when the tag is set to "router-link" and properly handles the click behavior. Additionally, it removes all Sass styles, performs a big cleanup, and uses `v-bind` for anchor attributes.

Closes #127