### PR TITLE
File containing all types

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,13 @@
     "type": "module",
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
-    "types": "./dist/components.d.ts",
+    "types": "./dist/index.d.ts",
     "files": [
         "dist/*",
         "src/*"
     ],
     "exports": {
         ".": {
-            "types": "./dist/components.d.ts",
             "import": "./dist/index.js",
             "require": "./dist/index.cjs"
         },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
             "import": "./dist/index.js",
             "require": "./dist/index.cjs"
         },
+        "./types": "./src/types.ts",
         "./styles/core": "./src/assets/scss/main.scss",
         "./styles/reset": "./src/assets/scss/ress.scss",
         "./scripts/utils": "./src/utils/index.ts",

--- a/src/components/QuesoClickable/types.ts
+++ b/src/components/QuesoClickable/types.ts
@@ -1,7 +1,7 @@
-export type ClickableTag = "button" | "a" | "router-link" | "div" | "span";
+export type QuesoClickableMarkup = "button" | "a" | "router-link" | "div" | "span";
 
 export interface QuesoClickableProps {
-    markup?: ClickableTag;
+    markup?: QuesoClickableMarkup;
     url?: string | object;
     isDisabled?: boolean;
     isExternal?: boolean;

--- a/src/components/QuesoCollapsible/QuesoCollapsible.vue
+++ b/src/components/QuesoCollapsible/QuesoCollapsible.vue
@@ -32,14 +32,16 @@
 import { computed, ref, onBeforeMount, watch } from "vue";
 import { useElementBounding } from "@vueuse/core";
 
+import type { QuesoCollapsibleProps } from "./types";
+
 // Define Props/Emits
-export interface Props {
-    expandOnMount?: boolean;
-}
+const props = defineProps<QuesoCollapsibleProps>();
 
-const props = defineProps<Props>();
-
-const emit = defineEmits(["open", "close", "toggle"]);
+const emit = defineEmits<{
+    "collapsible:open": [];
+    "collapsible:close": [];
+    "collapsible:toggle": [boolean];
+}>();
 
 // Computeds
 const collapsibleContent = ref<HTMLElement>();
@@ -91,12 +93,12 @@ const toggle = (bool: boolean = false) => {
  */
 watch(isCollapsibleOpen, (newValue: boolean) => {
     if (newValue) {
-        emit("open");
+        emit("collapsible:open");
     } else {
-        emit("close");
+        emit("collapsible:close");
     }
 
-    emit("toggle", newValue);
+    emit("collapsible:toggle", newValue);
 });
 
 /**

--- a/src/components/QuesoCollapsible/index.ts
+++ b/src/components/QuesoCollapsible/index.ts
@@ -1,3 +1,4 @@
 import QuesoCollapsible from "./QuesoCollapsible.vue";
 
 export default QuesoCollapsible;
+export type * from "./types";

--- a/src/components/QuesoCollapsible/types.ts
+++ b/src/components/QuesoCollapsible/types.ts
@@ -1,0 +1,3 @@
+export interface QuesoCollapsibleProps {
+    expandOnMount?: boolean;
+}

--- a/src/components/QuesoIcon/QuesoIcon.vue
+++ b/src/components/QuesoIcon/QuesoIcon.vue
@@ -12,20 +12,15 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-interface Props {
-    svg?: SVGElement | string;
-    name?: string;
-    prefix?: string;
-    size?: number;
-    rotation?: number;
-}
+import type { QuesoIconProps } from "./types";
 
-const props = withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<QuesoIconProps>(), {
     size: 1,
+    sizeUnit: "rem",
     rotation: 0,
 });
 
-const iconID = computed(() => {
+const iconID = computed<string>(() => {
     const prefix = props.prefix ? `${props.prefix}-` : "";
     return `#${prefix}${props.name}`;
 });
@@ -39,22 +34,22 @@ const iconClasses = computed(() => {
 });
 
 // Visual
-const width = computed<string>(() => `${props.size}rem`);
+const width = computed<string>(() => `${props.size}${props.sizeUnit}`);
 const rotation = computed<string>(() => `${props.rotation}deg`);
 </script>
 
 <style lang="scss">
 .queso-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    vertical-align: middle;
+    display: var(--queso-icon-display, inline-flex);
+    align-items: var(--queso-icon-align, center);
+    justify-content: var(--queso-icon-justify, center);
+    vertical-align: var(--queso-icon-vertical-align, middle);
 
     svg {
         display: block;
         width: var(--queso-icon-width, v-bind("width"));
         height: calc(var(--queso-icon-height, var(--queso-icon-width, v-bind("width"))) * var(--queso-icon-ratio, 1));
-        fill: currentColor;
+        fill: var(--queso-icon-fill, currentColor);
         transform: rotate(var(--queso-icon-rotation, v-bind("rotation")));
     }
 }

--- a/src/components/QuesoIcon/index.ts
+++ b/src/components/QuesoIcon/index.ts
@@ -1,3 +1,4 @@
 import QuesoIcon from "./QuesoIcon.vue";
 
 export default QuesoIcon;
+export type * from "./types";

--- a/src/components/QuesoIcon/types.ts
+++ b/src/components/QuesoIcon/types.ts
@@ -1,0 +1,26 @@
+export type QuesoIconSizeUnit =
+    | "px"
+    | "cm"
+    | "mm"
+    | "in"
+    | "pt"
+    | "pc"
+    | "em"
+    | "rem"
+    | "ex"
+    | "ch"
+    | "vw"
+    | "vh"
+    | "vmin"
+    | "vmax"
+    | "%"
+    | "fr";
+
+export interface QuesoIconProps {
+    svg?: SVGElement | string;
+    name?: string;
+    prefix?: string;
+    size?: number;
+    sizeUnit?: QuesoIconSizeUnit;
+    rotation?: number;
+}

--- a/src/components/QuesoModal/QuesoModal.vue
+++ b/src/components/QuesoModal/QuesoModal.vue
@@ -1,13 +1,13 @@
 <template>
     <Teleport to="body">
         <div class="queso-modal" :class="{ 'is-modal-open': isModalOpen }" :aria-expanded="isModalOpen" v-bind="$attrs">
-            <slot name="before-content"></slot>
+            <slot name="beforeContent"></slot>
 
-            <div class="queso-modal__inner">
+            <div class="queso-modal__content">
                 <slot></slot>
             </div>
 
-            <slot name="after-content"></slot>
+            <slot name="afterContent"></slot>
 
             <slot name="overlay">
                 <queso-modal-overlay />
@@ -16,25 +16,24 @@
     </Teleport>
 </template>
 
-<script lang="ts">
-import { ModalMethodsKey } from "./symbols";
-</script>
-
 <script setup lang="ts">
 import { ref, watch, onMounted, provide } from "vue";
 
-import QuesoModalOverlay from "./components/QuesoModalOverlay.vue";
+import { QuesoModalMethodsKey } from "./types";
+import type { QuesoModalMethods, QuesoModalOpen, QuesoModalClose } from "./types";
+
+import QuesoModalOverlay from "./components/QuesoModalOverlay";
 
 const emit = defineEmits(["modal:open", "modal:close"]);
 
 // Open/Close modal
 const isModalOpen = ref<boolean>(false);
 
-const open = () => {
+const open: QuesoModalOpen = () => {
     isModalOpen.value = true;
 };
 
-const close = () => {
+const close: QuesoModalClose = () => {
     isModalOpen.value = false;
 };
 
@@ -61,7 +60,7 @@ onMounted(() => {
 });
 
 // Provide and Expose open/close methods
-provide(ModalMethodsKey, { open, close });
+provide(QuesoModalMethodsKey, { open, close } as QuesoModalMethods);
 
 defineExpose({ isModalOpen, open, close });
 </script>
@@ -84,7 +83,7 @@ defineExpose({ isModalOpen, open, close });
     z-index: var(--queso-modal-z, 400);
     opacity: var(--queso-modal-opacity);
 
-    &__inner {
+    &__content {
         max-width: var(--queso-modal-max-width);
         max-height: var(--queso-modal-max-height);
         position: relative;

--- a/src/components/QuesoModal/components/QuesoModalOverlay/QuesoModalOverlay.vue
+++ b/src/components/QuesoModal/components/QuesoModalOverlay/QuesoModalOverlay.vue
@@ -2,15 +2,13 @@
     <div class="queso-modal__overlay" @click="close"></div>
 </template>
 
-<script lang="ts">
-import { ModalMethodsKey } from "../symbols";
-import type { ModalMethods } from "../types";
-</script>
-
 <script setup lang="ts">
 import { inject } from "vue";
 
-const { close } = inject(ModalMethodsKey) as ModalMethods;
+import { QuesoModalMethodsKey } from "../../types";
+
+const methods = inject(QuesoModalMethodsKey);
+const close = methods?.close;
 </script>
 
 <style lang="scss">

--- a/src/components/QuesoModal/components/QuesoModalOverlay/index.ts
+++ b/src/components/QuesoModal/components/QuesoModalOverlay/index.ts
@@ -1,0 +1,3 @@
+import QuesoModalOverlay from "./QuesoModalOverlay.vue";
+
+export default QuesoModalOverlay;

--- a/src/components/QuesoModal/index.ts
+++ b/src/components/QuesoModal/index.ts
@@ -1,3 +1,4 @@
 import QuesoModal from "./QuesoModal.vue";
 
 export default QuesoModal;
+export type * from "./types";

--- a/src/components/QuesoModal/symbols.ts
+++ b/src/components/QuesoModal/symbols.ts
@@ -1,4 +1,0 @@
-import { ModalMethods } from "./types";
-import type { InjectionKey } from "vue";
-
-export const ModalMethodsKey: InjectionKey<ModalMethods> = Symbol("ModalMethodsKey");

--- a/src/components/QuesoModal/types.ts
+++ b/src/components/QuesoModal/types.ts
@@ -1,4 +1,11 @@
-export interface ModalMethods {
-    open: () => void;
-    close: () => void;
+import type { InjectionKey } from "vue";
+
+export type QuesoModalOpen = () => void;
+export type QuesoModalClose = () => void;
+
+export interface QuesoModalMethods {
+    open: QuesoModalOpen;
+    close: QuesoModalClose;
 }
+
+export const QuesoModalMethodsKey: InjectionKey<QuesoModalMethods> = Symbol();

--- a/src/components/QuesoScrollable/QuesoScrollable.vue
+++ b/src/components/QuesoScrollable/QuesoScrollable.vue
@@ -17,8 +17,8 @@ const props = withDefaults(defineProps<QuesoScrollableProps>(), {
 });
 
 const emit = defineEmits<{
-    "scroll:top:arrived": [];
-    "scroll:bottom:arrived": [];
+    "scrollable:top:arrived": [];
+    "scrollable:bottom:arrived": [];
 }>();
 
 const content = ref<HTMLElement>();
@@ -52,10 +52,10 @@ const isArrivedAtBottom = computed(() => {
 // Watcher to emit events
 watchEffect(() => {
     if (isArrivedAtTop.value) {
-        emit("scroll:top:arrived");
+        emit("scrollable:top:arrived");
     }
     if (isArrivedAtBottom.value) {
-        emit("scroll:bottom:arrived");
+        emit("scrollable:bottom:arrived");
     }
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,30 @@
+// Bases
+import type { QuesoClickableMarkup, QuesoClickableProps } from "@components/QuesoClickable";
+import type { QuesoCollapsibleProps } from "@components/QuesoCollapsible";
+import type { QuesoIconSizeUnit, QuesoIconProps } from "@components/QuesoIcon";
+import type { QuesoModalOpen, QuesoModalClose, QuesoModalMethods } from "@components/QuesoModal";
+import type { QuesoScrollableProps } from "@components/QuesoScrollable";
+
+// Fields
+// Coming after PR #132 is merged
+
+/*====================================
+=              EXPORTS               =
+====================================*/
+
+export {
+    // Clickable
+    QuesoClickableMarkup,
+    QuesoClickableProps,
+    // Collapsible
+    QuesoCollapsibleProps,
+    // Icon
+    QuesoIconSizeUnit,
+    QuesoIconProps,
+    // Modal
+    QuesoModalOpen,
+    QuesoModalClose,
+    QuesoModalMethods,
+    // Scrollable
+    QuesoScrollableProps,
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,7 +55,13 @@ export default defineConfig(({ command, mode }) => {
                 "@components": resolve(__dirname, "./src/components"),
             },
         },
-        plugins: [vue(), libInjectCss(), dts()],
+        plugins: [
+            vue(),
+            libInjectCss(),
+            dts({
+                rollupTypes: true,
+            }),
+        ],
         optimizeDeps: {
             include: ["vue"],
             exclude: [],


### PR DESCRIPTION
Closes #131

This pull request fixes the issue with the Icon component where the width unit prop was missing. The missing prop caused the width of the icon to be inconsistent. With this fix, the width unit prop is added to the Icon component, allowing developers to specify the unit for the width of the icon.

The following commits are included in this pull request:

- QuesoCollapsible - Upgrade typing

- Add prefix Queso to type

- Icon - Props for width unit #145

- Adapt emit to be as component name

- QuesoModal cleanup

- Types file

- Cleanup and rename declaration file

- Add types to package

Please review and merge this pull request.