### PR TITLE
Radio & CheckboxMultiple / Add choice object in slots' exposed data

### DIFF
--- a/docs/components/checkbox-multiple.md
+++ b/docs/components/checkbox-multiple.md
@@ -52,7 +52,7 @@ const interestChoices = [
 
 -   **Type:** `QuesoCheckboxMultipleChoices`
 -   **Required:** `true`
--   **Description:** Array of choices for the checkbox group. Each choice must have a `label` and `value`.
+-   **Description:** Array of choices for the checkbox group. Each choice must have a `label` and `value`, with optional `data`.
 
 ### `validationMessage`
 
@@ -119,22 +119,22 @@ const interestChoices = [
 
 ### `checkbox`
 
--   **Props:** `ExposedData & { isHovered: boolean, isSelected: boolean }`
+-   **Props:** `ExposedData & QuesoCheckboxMultipleChoice & { isHovered: boolean, isSelected: boolean }`
 -   **Description:** Custom checkbox container element for each choice. Defaults to a styled checkbox container.
 
 ### `checkboxBox`
 
--   **Props:** `ExposedData & { isHovered: boolean, isSelected: boolean }`
+-   **Props:** `ExposedData & QuesoCheckboxMultipleChoice & { isHovered: boolean, isSelected: boolean }`
 -   **Description:** Custom checkbox box element for each choice. Defaults to a styled checkbox box.
 
 ### `checkboxBoxSymbol`
 
--   **Props:** `ExposedData & { isHovered: boolean, isSelected: boolean }`
+-   **Props:** `ExposedData & QuesoCheckboxMultipleChoice & { isHovered: boolean, isSelected: boolean }`
 -   **Description:** Symbol displayed inside the checkbox box when checked. Defaults to "✔︎".
 
 ### `checkboxLabel`
 
--   **Props:** `ExposedData & { isHovered: boolean, isSelected: boolean }`
+-   **Props:** `ExposedData & QuesoCheckboxMultipleChoice & { isHovered: boolean, isSelected: boolean }`
 -   **Description:** Custom label element for each choice. Defaults to the choice label.
 
 ### `afterInput`
@@ -615,6 +615,7 @@ export interface QuesoCheckboxMultipleChoice {
     label: string;
     value: string;
     isChecked?: boolean;
+    data?: object;
 }
 
 export type QuesoCheckboxMultipleChoices = QuesoCheckboxMultipleChoice[];

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -51,7 +51,7 @@ const genderChoices = [
 
 -   **Type:** `QuesoRadioChoice[]`
 -   **Required:** `true`
--   **Description:** Array of choices for the radio group. Each choice must have a `label` and `value`.
+-   **Description:** Array of choices for the radio group. Each choice must have a `label` and `value`, with optional `data`.
 
 ### `isRequired`
 
@@ -112,22 +112,22 @@ const genderChoices = [
 
 ### `radio`
 
--   **Props:** `ExposedData & { isHovered: boolean, isSelected: boolean }`
+-   **Props:** `ExposedData & QuesoRadioChoice & { isHovered: boolean, isSelected: boolean }`
 -   **Description:** Custom radio container element for each choice. Defaults to a styled radio container.
 
 ### `radioBox`
 
--   **Props:** `ExposedData & { isHovered: boolean, isSelected: boolean }`
+-   **Props:** `ExposedData & QuesoRadioChoice & { isHovered: boolean, isSelected: boolean }`
 -   **Description:** Custom radio box element for each choice. Defaults to a styled radio box.
 
 ### `radioBoxSymbol`
 
--   **Props:** `ExposedData & { isHovered: boolean, isSelected: boolean }`
+-   **Props:** `ExposedData & QuesoRadioChoice & { isHovered: boolean, isSelected: boolean }`
 -   **Description:** Symbol displayed inside the radio box when selected. Defaults to "✔︎".
 
 ### `radioLabel`
 
--   **Props:** `ExposedData & { isHovered: boolean, isSelected: boolean }`
+-   **Props:** `ExposedData & QuesoRadioChoice & { isHovered: boolean, isSelected: boolean }`
 -   **Description:** Custom label element for each choice. Defaults to the choice label.
 
 ### `afterInput`
@@ -549,6 +549,7 @@ export interface ExposedData {
 export interface QuesoRadioChoice {
     label: string;
     value: string;
+    data?: object;
 }
 
 export type QuesoRadioChoices = QuesoRadioChoice[];

--- a/src/components/QuesoCheckboxMultiple/QuesoCheckboxMultiple.vue
+++ b/src/components/QuesoCheckboxMultiple/QuesoCheckboxMultiple.vue
@@ -51,6 +51,7 @@
                     name="checkbox"
                     v-bind="{
                         ...exposedData,
+                        ...choice,
                         isHovered: hoveredChoice === choice.value,
                         isSelected: choice.isChecked,
                     }"
@@ -59,6 +60,7 @@
                         name="checkboxBox"
                         v-bind="{
                             ...exposedData,
+                            ...choice,
                             isHovered: hoveredChoice === choice.value,
                             isSelected: choice.isChecked,
                         }"
@@ -69,6 +71,7 @@
                                     name="checkboxBoxSymbol"
                                     v-bind="{
                                         ...exposedData,
+                                        ...choice,
                                         isHovered: hoveredChoice === choice.value,
                                         isSelected: choice.isChecked,
                                     }"
@@ -82,6 +85,7 @@
                         name="checkboxLabel"
                         v-bind="{
                             ...exposedData,
+                            ...choice,
                             isHovered: hoveredChoice === choice.value,
                             isSelected: choice.isChecked,
                         }"

--- a/src/components/QuesoCheckboxMultiple/types.ts
+++ b/src/components/QuesoCheckboxMultiple/types.ts
@@ -6,6 +6,7 @@ export interface QuesoCheckboxMultipleChoice {
     label: QuesoCheckboxProps["boxLabel"];
     value: string;
     isChecked?: QuesoCheckboxModel;
+    data?: object;
 }
 
 export type QuesoCheckboxMultipleChoices = QuesoCheckboxMultipleChoice[];

--- a/src/components/QuesoRadio/QuesoRadio.vue
+++ b/src/components/QuesoRadio/QuesoRadio.vue
@@ -54,6 +54,7 @@
                     name="radio"
                     v-bind="{
                         ...exposedData,
+                        ...choice,
                         isHovered: hoveredChoice === choice.value,
                         isSelected: model === choice.value,
                     }"
@@ -62,6 +63,7 @@
                         name="radioBox"
                         v-bind="{
                             ...exposedData,
+                            ...choice,
                             isHovered: hoveredChoice === choice.value,
                             isSelected: model === choice.value,
                         }"
@@ -72,6 +74,7 @@
                                     name="radioBoxSymbol"
                                     v-bind="{
                                         ...exposedData,
+                                        ...choice,
                                         isHovered: hoveredChoice === choice.value,
                                         isSelected: model === choice.value,
                                     }"
@@ -85,6 +88,7 @@
                         name="radioLabel"
                         v-bind="{
                             ...exposedData,
+                            ...choice,
                             isHovered: hoveredChoice === choice.value,
                             isSelected: model === choice.value,
                         }"

--- a/src/components/QuesoRadio/types.ts
+++ b/src/components/QuesoRadio/types.ts
@@ -4,6 +4,7 @@ import type { QuesoFieldProps, QuesoFieldBase } from "@components/QuesoField";
 export interface QuesoRadioChoice {
     label: string;
     value: string;
+    data?: object;
 }
 
 export type QuesoRadioChoices = QuesoRadioChoice[];


### PR DESCRIPTION
Expose the complete choice object in component slots to allow access to additional metadata.

## Changes
- Add `data?: object` property to choice interfaces
- Spread choice object in all choice-related slots
- Update documentation to reflect new slot props

Closes #240