### PR TITLE
Extract QuesoModal migration guide to dedicated page

### DIFF
--- a/docs/components/modal-migration.md
+++ b/docs/components/modal-migration.md
@@ -1,0 +1,117 @@
+---
+next: false
+---
+
+# QuesoModal Migration Guide (0.4.1 → 0.4.2)
+
+This guide explains how to migrate your code when upgrading `QuesoModal` from version `0.4.1` (and earlier) to `0.4.2`.
+
+Two breaking changes have been introduced:
+
+1. **Method names changed:** `open()`/`close()` → `openModal()`/`closeModal()` for better clarity.
+2. **New recommended approach:** Use the `trigger` slot instead of `ref` for simpler code.
+
+If you are upgrading from `0.4.1` or earlier, follow the steps below.
+
+## Recommended: Migrate to trigger slot
+
+**Before (with ref):**
+
+```vue
+<template>
+    <button @click="openModal()">Open modal</button>
+
+    <queso-modal ref="myModal">
+        <p>This is the modal content.</p>
+    </queso-modal>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { QuesoModal } from "@components/QuesoModal";
+
+const myModal = ref<InstanceType<typeof QuesoModal> | null>(null);
+
+const openModal = () => {
+    myModal.value?.open();
+};
+
+const closeModal = () => {
+    myModal.value?.close();
+};
+</script>
+```
+
+**After (with trigger slot - recommended):**
+
+```vue
+<template>
+    <queso-modal>
+        <template #trigger="{ openModal }">
+            <button @click="openModal">Open modal</button>
+        </template>
+
+        <p>This is the modal content.</p>
+    </queso-modal>
+</template>
+
+<script setup lang="ts">
+import { QuesoModal } from "@components/QuesoModal";
+</script>
+```
+
+## Alternative: Keep using ref (update method names)
+
+If you need to keep using `ref` for programmatic control, update the method names:
+
+**Before:**
+
+```vue
+<template>
+    <button @click="openModal()">Open modal</button>
+
+    <queso-modal ref="myModal">
+        <template #default="{ close }">
+            <button @click="close">Close</button>
+        </template>
+    </queso-modal>
+</template>
+
+<script setup lang="ts">
+const myModal = ref<InstanceType<typeof QuesoModal> | null>(null);
+
+const openModal = () => {
+    myModal.value?.open();
+};
+
+const closeModal = () => {
+    myModal.value?.close();
+};
+</script>
+```
+
+**After:**
+
+```vue
+<template>
+    <button @click="openModal()">Open modal</button>
+
+    <queso-modal ref="myModal">
+        <template #default="{ closeModal }">
+            <button @click="closeModal">Close</button>
+        </template>
+    </queso-modal>
+</template>
+
+<script setup lang="ts">
+const myModal = ref<InstanceType<typeof QuesoModal> | null>(null);
+
+const openModal = () => {
+    myModal.value?.openModal();
+};
+
+const closeModal = () => {
+    myModal.value?.closeModal();
+};
+</script>
+```

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -5,120 +5,15 @@ A modal component with comprehensive accessibility support, focus management, an
 ## Breaking Changes
 
 ::: danger Breaking Change
-**Version:** These breaking changes are introduced in version `0.4.2`. If you're upgrading from version `0.4.1` or earlier to `0.4.2`, you must follow the migration guide below to update your code.
+**Version:** These breaking changes are introduced in version `0.4.2`. If you're upgrading from version `0.4.1` or earlier to `0.4.2`, you must follow the migration guide to update your code.
 
 Two breaking changes have been introduced:
 
 1. **Method names changed:** `open()`/`close()` → `openModal()`/`closeModal()` for better clarity
 2. **New recommended approach:** Use the `trigger` slot instead of `ref` for simpler code
 
-**Migration required:** Update all references from `open` → `openModal` and `close` → `closeModal`, and consider migrating to the `trigger` slot approach.
+**Migration required:** Update all references from `open` → `openModal` and `close` → `closeModal`, and consider migrating to the `trigger` slot approach. See the [QuesoModal migration guide](/components/modal-migration) for full examples and steps.
 :::
-
-### Migration Guide
-
-#### Recommended: Migrate to trigger slot
-
-**Before (with ref):**
-
-```vue
-<template>
-    <button @click="openModal()">Open modal</button>
-
-    <queso-modal ref="myModal">
-        <p>This is the modal content.</p>
-    </queso-modal>
-</template>
-
-<script setup lang="ts">
-import { ref } from "vue";
-import { QuesoModal } from "@components/QuesoModal";
-
-const myModal = ref<InstanceType<typeof QuesoModal> | null>(null);
-
-const openModal = () => {
-    myModal.value?.open();
-};
-
-const closeModal = () => {
-    myModal.value?.close();
-};
-</script>
-```
-
-**After (with trigger slot - recommended):**
-
-```vue
-<template>
-    <queso-modal>
-        <template #trigger="{ openModal }">
-            <button @click="openModal">Open modal</button>
-        </template>
-
-        <p>This is the modal content.</p>
-    </queso-modal>
-</template>
-
-<script setup lang="ts">
-import { QuesoModal } from "@components/QuesoModal";
-</script>
-```
-
-#### Alternative: Keep using ref (update method names)
-
-If you need to keep using `ref` for programmatic control, update the method names:
-
-**Before:**
-
-```vue
-<template>
-    <button @click="openModal()">Open modal</button>
-
-    <queso-modal ref="myModal">
-        <template #default="{ close }">
-            <button @click="close">Close</button>
-        </template>
-    </queso-modal>
-</template>
-
-<script setup lang="ts">
-const myModal = ref<InstanceType<typeof QuesoModal> | null>(null);
-
-const openModal = () => {
-    myModal.value?.open();
-};
-
-const closeModal = () => {
-    myModal.value?.close();
-};
-</script>
-```
-
-**After:**
-
-```vue
-<template>
-    <button @click="openModal()">Open modal</button>
-
-    <queso-modal ref="myModal">
-        <template #default="{ closeModal }">
-            <button @click="closeModal">Close</button>
-        </template>
-    </queso-modal>
-</template>
-
-<script setup lang="ts">
-const myModal = ref<InstanceType<typeof QuesoModal> | null>(null);
-
-const openModal = () => {
-    myModal.value?.openModal();
-};
-
-const closeModal = () => {
-    myModal.value?.closeModal();
-};
-</script>
-```
 
 ## Basic Usage
 
@@ -143,7 +38,7 @@ import { QuesoModal } from "@components/QuesoModal";
 ::: warning Warning
 The method below is still supported for backward compatibility, but the `trigger` slot approach is preferred for new code. Use it only if you need programmatic control from multiple places or complex conditional logic.
 
-See the [Migration Guide](#breaking-changes) for detailed examples and migration steps.
+See the [QuesoModal migration guide](/components/modal-migration) for detailed examples and migration steps.
 :::
 
 <details>


### PR DESCRIPTION
## Summary
- Move the detailed QuesoModal migration instructions from the main modal documentation into a new dedicated page `modal-migration.md`
- Keep a concise breaking change warning in `modal.md` and link to the new migration guide for full details
- Add VitePress frontmatter to the migration page to disable the automatic “Next” link, keeping it self-contained in the docs navigation
- Update legacy usage warning in `modal.md` to reference the new migration guide path

Closes #252