### PR TITLE
Fix field tests for radio, checkboxes and clickable

### DIFF
--- a/src/components/QuesoCheckbox/QuesoCheckbox.test.ts
+++ b/src/components/QuesoCheckbox/QuesoCheckbox.test.ts
@@ -16,13 +16,14 @@ describe("QuesoCheckbox", () => {
 
     test("renders correctly the label", () => {
         const data = {
-            label: "field-label",
+            name: "field-name",
+            boxLabel: "field-label",
         };
 
         const wrapper = mount(QuesoCheckbox, {
             props: data,
         });
-        expect(wrapper.find(".queso-checkbox__label__text").text()).toBe(data.label);
+        expect(wrapper.find(".queso-checkbox__label__text").text()).toBe(data.boxLabel);
     });
 
     test("renders correctly the checkbox symbol", () => {

--- a/src/components/QuesoCheckboxMultiple/QuesoCheckboxMultiple.test.ts
+++ b/src/components/QuesoCheckboxMultiple/QuesoCheckboxMultiple.test.ts
@@ -9,6 +9,17 @@ describe("QuesoCheckboxMultiple.vue", () => {
     ];
 
     const props = {
+        name: "checkbox-multiple-name",
+        label: "Checkbox multiple label",
+        isRequired: true,
+        choices,
+    };
+
+    const propsWithError = {
+        name: "checkbox-multiple-name",
+        label: "Checkbox multiple label",
+        isRequired: true,
+        isError: true,
         choices,
     };
 
@@ -27,19 +38,18 @@ describe("QuesoCheckboxMultiple.vue", () => {
         const wrapper = mount(QuesoCheckboxMultiple, { props });
         const checkbox = wrapper.find(".queso-checkbox__native");
         await checkbox.setChecked();
-        expect(wrapper.vm.model.value).toContain("choice1");
+        expect(wrapper.emitted()["update:modelValue"][0][0]).toContain("choice1");
     });
 
     it("renders slots correctly", () => {
         const wrapper = mount(QuesoCheckboxMultiple, {
-            props,
+            props: propsWithError,
             slots: {
                 beforeLabel: '<div class="before-label">Before Label</div>',
                 label: '<div class="label">Label</div>',
                 required: '<div class="required">Required</div>',
                 afterLabel: '<div class="after-label">After Label</div>',
                 beforeInput: '<div class="before-input">Before Input</div>',
-                input: '<div class="input">Input</div>',
                 afterInput: '<div class="after-input">After Input</div>',
                 error: '<div class="error">Error</div>',
             },
@@ -50,7 +60,6 @@ describe("QuesoCheckboxMultiple.vue", () => {
         expect(wrapper.find(".required").exists()).toBe(true);
         expect(wrapper.find(".after-label").exists()).toBe(true);
         expect(wrapper.find(".before-input").exists()).toBe(true);
-        expect(wrapper.find(".input").exists()).toBe(true);
         expect(wrapper.find(".after-input").exists()).toBe(true);
         expect(wrapper.find(".error").exists()).toBe(true);
     });

--- a/src/components/QuesoClickable/QuesoClickable.test.js
+++ b/src/components/QuesoClickable/QuesoClickable.test.js
@@ -1,13 +1,11 @@
-// import { localVue, i18n } from "../testUtils";
 import { mount, shallowMount } from "@vue/test-utils";
 import { describe, expect, it, test } from "vitest";
 import QuesoClickable from "./QuesoClickable.vue";
 
 describe("QuesoClickable", () => {
     const data = {
-        label: "label test",
-        href: "https://www.google.ca/",
-        tag: "a",
+        url: "https://www.google.ca/",
+        markup: "a",
         isExternal: true,
     };
 
@@ -19,28 +17,28 @@ describe("QuesoClickable", () => {
     // Anchor
     test("renders correctly anchor", () => {
         const wrapper = shallowMount(QuesoClickable, {
-            propsData: data,
+            props: data,
         });
         expect(wrapper.element.tagName).toBe("A");
     });
 
     test("renders correctly anchor with a href", () => {
         const wrapper = shallowMount(QuesoClickable, {
-            propsData: data,
+            props: data,
         });
-        expect(wrapper.attributes("href")).toBe(data.href);
+        expect(wrapper.attributes("href")).toBe(data.url);
     });
 
     test("renders correctly anchor with target blank", () => {
         const wrapper = shallowMount(QuesoClickable, {
-            propsData: data,
+            props: data,
         });
         expect(wrapper.attributes("target")).toBe("_blank");
     });
     // Disabled
     test("renders correctly disabled button", () => {
         const wrapper = shallowMount(QuesoClickable, {
-            propsData: { isDisabled: true },
+            props: { isDisabled: true },
         });
         expect(wrapper.attributes("disabled")).toBe("");
     });

--- a/src/components/QuesoRadio/QuesoRadio.test.ts
+++ b/src/components/QuesoRadio/QuesoRadio.test.ts
@@ -9,23 +9,34 @@ describe("QuesoRadio.vue", () => {
     ];
 
     const props = {
+        name: "radio-name",
+        label: "Radio label",
         choices,
         modelValue: "",
     };
 
+    const propsWithError = {
+        name: "radio-name",
+        label: "Radio label",
+        choices,
+        modelValue: "",
+        isRequired: true,
+        isError: true,
+    };
+
     test("renders correctly", () => {
-        const wrapper = mount(QuesoRadio, { props });
+        const wrapper = mount(QuesoRadio, { props: props });
         expect(wrapper.exists()).toBe(true);
     });
 
     test("renders radio buttons based on choices prop", () => {
-        const wrapper = mount(QuesoRadio, { props });
+        const wrapper = mount(QuesoRadio, { props: props });
         const radioButtons = wrapper.findAll(".queso-radio__native");
         expect(radioButtons.length).toBe(choices.length);
     });
 
     test("updates model when a radio button is selected", async () => {
-        const wrapper = mount(QuesoRadio, { props });
+        const wrapper = mount(QuesoRadio, { props: props });
         const radioButton = wrapper.find(".queso-radio__native");
         await radioButton.setChecked();
         expect(wrapper.emitted()["update:modelValue"][0]).toEqual(["choice1"]);
@@ -33,14 +44,13 @@ describe("QuesoRadio.vue", () => {
 
     test("renders slots correctly", () => {
         const wrapper = mount(QuesoRadio, {
-            props,
+            props: propsWithError,
             slots: {
                 beforeLabel: '<div class="before-label">Before Label</div>',
                 label: '<div class="label">Label</div>',
                 required: '<div class="required">Required</div>',
                 afterLabel: '<div class="after-label">After Label</div>',
                 beforeInput: '<div class="before-input">Before Input</div>',
-                input: '<div class="input">Input</div>',
                 afterInput: '<div class="after-input">After Input</div>',
                 error: '<div class="error">Error</div>',
             },
@@ -51,7 +61,6 @@ describe("QuesoRadio.vue", () => {
         expect(wrapper.find(".required").exists()).toBe(true);
         expect(wrapper.find(".after-label").exists()).toBe(true);
         expect(wrapper.find(".before-input").exists()).toBe(true);
-        expect(wrapper.find(".input").exists()).toBe(true);
         expect(wrapper.find(".after-input").exists()).toBe(true);
         expect(wrapper.find(".error").exists()).toBe(true);
     });


### PR DESCRIPTION
## Summary
- Update `QuesoCheckbox` tests to use the correct `boxLabel` prop and align expectations with the rendered label structure
- Adjust `QuesoCheckboxMultiple` tests to work with the new model handling and slot behavior, including proper props for label, required, and error states
- Fix `QuesoClickable` tests to use the current `markup` and `url` props and validate external anchor behavior and disabled state
- Update `QuesoRadio` tests to pass the required field props and accurately exercise slot rendering for label, required, and error


closes #253